### PR TITLE
redesign: center dB favicon glyphs

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,15 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <rect width="64" height="64" fill="#0a0a0a"/>
-  <text x="8" y="50"
+  <text x="32" y="48"
         font-family="Georgia, 'Times New Roman', serif"
         font-style="italic"
         font-weight="400"
-        font-size="54"
-        fill="#4ad8ff">d</text>
-  <text x="32" y="50"
-        font-family="Georgia, 'Times New Roman', serif"
-        font-style="italic"
-        font-weight="400"
-        font-size="54"
-        fill="#f0ece4">B</text>
+        font-size="46"
+        text-anchor="middle"
+        letter-spacing="-2">
+    <tspan fill="#4ad8ff">d</tspan><tspan fill="#f0ece4">B</tspan>
+  </text>
 </svg>


### PR DESCRIPTION
Switch from two absolute-positioned <text> elements to a single text node with text-anchor=middle + tspans, so the monogram sits centered in the viewBox instead of hugging the right edge.